### PR TITLE
Update Java 23 specific test with GA version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java-version: [ '17', '18', '19', '20', '21', '22', '23-ea' ]
+        java-version: [ '17', '18', '19', '20', '21', '22', '23' ]
 
     runs-on: ubuntu-latest
 
@@ -36,14 +36,14 @@ jobs:
       uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
       with:
         java-version: ${{ matrix.java-version }}
-        distribution: 'temurin'
+        distribution: 'oracle'
 
     # This is the JDK gradle will use since gradle does not always support the -ea version
     - name: Set up JDK 17
       uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
       with:
         java-version: '17'
-        distribution: 'temurin'
+        distribution: 'oracle'
         cache: gradle    
 
     - name: Toolchain debug


### PR DESCRIPTION
Updating the Java 23 build to use the GA version of Java 23.