### PR TITLE
Update Java 24 to use GA version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java-version: [ '17', '18', '19', '20', '21', '22', '23', '24-ea' ]
+        java-version: [ '17', '18', '19', '20', '21', '22', '23', '24' ]
 
     runs-on: ubuntu-latest
 
@@ -36,14 +36,14 @@ jobs:
       uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
       with:
         java-version: ${{ matrix.java-version }}
-        distribution: 'temurin'
+        distribution: 'oracle'
 
     # This is the JDK gradle will use since gradle does not always support the -ea version
     - name: Set up JDK 17
       uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
       with:
         java-version: '17'
-        distribution: 'temurin'
+        distribution: 'oracle'
         cache: gradle    
 
     - name: Toolchain debug


### PR DESCRIPTION
Add the GA version of Java 24 to use for builds now that Java 24 has been released.