### PR TITLE
Update Java 25 to use GA version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [ '17', '18', '19', '20', '21', '22', '23', '24', '25-ea' ]
+        java-version: [ '17', '18', '19', '20', '21', '22', '23', '24', '25' ]
 
     runs-on: ubuntu-latest
 
@@ -37,14 +37,14 @@ jobs:
       uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
       with:
         java-version: ${{ matrix.java-version }}
-        distribution: 'temurin'
+        distribution: 'oracle'
 
     # This is the JDK gradle will use since gradle does not always support the -ea version
     - name: Set up JDK 17
       uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
       with:
         java-version: '21'
-        distribution: 'temurin'
+        distribution: 'oracle'
         cache: gradle    
 
     - name: Toolchain debug


### PR DESCRIPTION
Add the GA version of Java 25 to use for builds once Java 25 is released.