### PR TITLE
Fix JEP 527 test to treat SecP256r1MLKEM768 and SecP384r1MLKEM1024 as optional

### DIFF
--- a/io.openliberty.java.internal_fat_27/src/main/java/io/openliberty/java/internal/TestService.java
+++ b/io.openliberty.java.internal_fat_27/src/main/java/io/openliberty/java/internal/TestService.java
@@ -55,6 +55,9 @@ public class TestService {
 
     // JEP 527: Post-Quantum Hybrid Key Exchange for TLS 1.3
     // https://openjdk.org/jeps/527
+    // X25519MLKEM768 is the primary hybrid group mandated by JEP 527 and must always
+    // be present. SecP256r1MLKEM768 and SecP384r1MLKEM1024 are optional; their
+    // availability is JDK-vendor/build-dependent (e.g. absent on Oracle JDK 27 EA).
 
     private void testPostQuantumTLS() throws Exception {
         log("Beginning JEP 527 testing: Post-Quantum Hybrid Key Exchange for TLS 1.3");
@@ -69,13 +72,17 @@ public class TestService {
         }
         log("Default TLS named groups (" + namedGroups.length + "): " + java.util.Arrays.toString(namedGroups));
 
-        // All three hybrid groups must be present; ordering is vendor-dependent
         java.util.Set<String> groups = new java.util.HashSet<>(java.util.Arrays.asList(namedGroups));
-        for (String hybrid : new String[]{"X25519MLKEM768", "SecP256r1MLKEM768", "SecP384r1MLKEM1024"}) {
-            if (!groups.contains(hybrid)) {
-                throw new Exception("JEP 527 FAILED: hybrid group missing from supported set: " + hybrid);
+        if (!groups.contains("X25519MLKEM768")) {
+            throw new Exception("JEP 527 FAILED: X25519MLKEM768 missing from default SSLParameters named groups");
+        }
+        log("Hybrid group present: X25519MLKEM768");
+        for (String hybrid : new String[]{"SecP256r1MLKEM768", "SecP384r1MLKEM1024"}) {
+            if (groups.contains(hybrid)) {
+                log("Hybrid group present: " + hybrid);
+            } else {
+                log("Hybrid group optional (not present on this JDK build): " + hybrid);
             }
-            log("Hybrid group present: " + hybrid);
         }
 
         log("Leaving JEP 527 testing");


### PR DESCRIPTION
Oracle JDK 27 EA only includes X25519MLKEM768 in the default SSLParameters named groups list. SecP256r1MLKEM768 and SecP384r1MLKEM1024 are not present on this build, causing the test to fail with:

  JEP 527 FAILED: hybrid group missing from supported set: SecP256r1MLKEM768

X25519MLKEM768 is the primary group mandated by JEP 527 and is hard-asserted. The other two groups are logged as optional when absent, allowing the test to pass on JDK builds that do not yet include them by default.

Co-authored-by-AI: IBM Bob 1.0.0